### PR TITLE
#23 fixed the issue of file name ./bin/generate_tfrc_credentials

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ tasks:
   - name: terraform
     before: |
       source ./bin/install_terraform_cli
-      source ./bin/generate_trfc_credentials
+      source ./bin/generate_tfrc_credentials
       source ./bin/set_tf_alias
   - name: aws-cli
     env:


### PR DESCRIPTION
fixed the bug of incorrect file name ./bin/generate_trfc_credentials referred in gitpod.yaml file. renamed it to ./bin/generate_tfrc_credentials